### PR TITLE
add migration adding types to formdata

### DIFF
--- a/config/migrations/2024/20240703132937-add-missing-subsidy-formdata-types.sparql
+++ b/config/migrations/2024/20240703132937-add-missing-subsidy-formdata-types.sparql
@@ -1,0 +1,351 @@
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/accountability-note-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/accountabilityNoteUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/ukraine-nooddorpen/accountability-proof/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/accountabilityProof> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/ukraine-nooddorpen/accountability-summary/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/accountabilitySummary> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/award-report-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/awardReportUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-four/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveFour> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-one/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveOne> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-three/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveThree> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-two/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveTwo> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?contactPoint <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/ContactPoint> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s <http://schema.org/contactPoint> ?contactPoint .
+    ?contactPoint ?p_c ?o_c .
+  }
+
+  FILTER NOT EXISTS {
+    ?contactPoint <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/decision-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/decisionUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/invoice-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/invoiceUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-costs-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/justificationCostsUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-expropriations-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/justificationExpropriationsUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/picturesUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?politicalReferenceContactPoint <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://mu.semte.ch/vocabularies/ext/PoliticalReferenceContactPoint> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://mu.semte.ch/vocabularies/ext/politicalReferenceContactPoint> ?politicalReferenceContactPoint .
+    ?politicalReferenceContactPoint ?p_p ?o_p .
+  }
+
+  FILTER NOT EXISTS {
+    ?politicalReferenceContactPoint <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/reportUpload> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/climate/signed-pact/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/signedPact> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/urban-renewal/urban-renewal-application-form/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/urbanRenewalApplicationForm> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/urban-renewal/urban-renewal-attachments/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/urbanRenewalAttachments> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/BankAccount> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://schema.org/bankAccount> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/climate/attachment/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/attachment> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}
+;
+INSERT {
+  GRAPH ?g {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/climate/attachment/FormData> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/attachmentLEKPReport> ?formData .
+    ?formData ?p_f ?o_f .
+  }
+
+  FILTER NOT EXISTS {
+    ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }
+}


### PR DESCRIPTION
## ID
DGS-330

## Description
replay of: https://github.com/lblod/app-digitaal-loket/pull/536/files
Some files where not correctly syncing to subsidiedatabank. This because rdf:types where missing. This is part of a deeper problem. Extractor doesnt run on subsidy forms that got created before the fix got implemented. This issue might re-occur

## Type of change

 - [X] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
Simply checkout the PR

## How to test
Check if migrations ran, then execute the following sparql query and see if a rdf:type is present

```
PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>

SELECT DISTINCT * WHERE {
  <http://data.lblod.info/id/application-forms/XYZ> #replace by correct form uuid <http://lblod.data.gift/vocabularies/subsidie/reportUpload> ?k.
?k ?t  ?o
} LIMIT 100
```
