### PR TITLE
Feature/mock login verenigingen

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -88,8 +88,7 @@ defmodule Acl.UserGroups.Config do
                         "http://data.europa.eu/m8g/Criterion",
                         "http://data.europa.eu/m8g/RequirementGroup",
                         "http://data.europa.eu/m8g/CriterionRequirement",
-                        "http://data.europa.eu/m8g/Requirement",
-                        "http://www.w3.org/ns/org#Organization"
+                        "http://data.europa.eu/m8g/Requirement"
                       ]
                     } },
                   %GraphSpec{

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -74,6 +74,8 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode",
                         "http://publications.europa.eu/ontology/euvoc#Country",
                         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
+                        "http://www.w3.org/ns/org#Organization",
+                        "http://mu.semte.ch/vocabularies/ext/OrganizationClassificationCode",
                         "http://www.w3.org/2004/02/skos/core#ConceptScheme",
                         "http://www.w3.org/2004/02/skos/core#Concept",
                         "http://lblod.data.gift/vocabularies/subsidie/SubsidiemaatregelConsumptieStatus",
@@ -144,6 +146,7 @@ defmodule Acl.UserGroups.Config do
                         constraint: %ResourceConstraint{
                           resource_types: [
                             "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
+                            "http://www.w3.org/ns/org#Organization",
                             # Sometimes a very specific list of organisations should be able submit for a subsidy.
                             # This is unfortunatly the most elegant way.
                             "http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelAanbod",

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -12,6 +12,14 @@ defmodule Dispatcher do
   #   forward conn, path, "http://resource/themes/"
   # end
 
+  match "/organisaties/*path" do
+    forward conn, path, "http://cache/organisaties/"
+  end
+
+  match "/organization-classification-codes/*path" do
+    forward conn, path, "http://cache/organization-classification-codes/"
+  end
+
   match "/bestuurseenheden/*path" do
     forward conn, path, "http://cache/bestuurseenheden/"
   end
@@ -42,7 +50,7 @@ defmodule Dispatcher do
     forward conn, path, "http://cache/gebruikers/"
   end
   match "/accounts/*path" do
-    forward conn, path, "http://cache/accounts/"
+    forward conn, path, "http://resource/accounts/"
   end
   match "/document-statuses/*path" do
     forward conn, path, "http://cache/document-statuses/"

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -12,8 +12,8 @@ defmodule Dispatcher do
   #   forward conn, path, "http://resource/themes/"
   # end
 
-  match "/organisaties/*path" do
-    forward conn, path, "http://cache/organisaties/"
+  match "/organizations/*path" do
+    forward conn, path, "http://cache/organizations/"
   end
 
   match "/organization-classification-codes/*path" do

--- a/config/migrations/2024/20240705152938-add-mock-VZW-account.sparql
+++ b/config/migrations/2024/20240705152938-add-mock-VZW-account.sparql
@@ -25,6 +25,7 @@ INSERT DATA {
         mu:uuid '3e5edbbb-26e0-49f9-9082-55f2297bd73a';
         skos:prefLabel "Mock VZW" ;
         dc:description "Mock VZW for testing" ;
+        org:classification <http://data.lblod.info/id/concept/c6157470-9fb3-4e8d-a9b7-8737dbfa3642> ;
         adms:identifier <http://data.lblod.info/id/identificatoren/4faddea9-b959-4eed-aa4e-b6ec84b14249>.
 
     <http://data.lblod.info/id/identificatoren/4faddea9-b959-4eed-aa4e-b6ec84b14249> a adms:Identifier;

--- a/config/migrations/2024/20240705152938-add-mock-VZW-account.sparql
+++ b/config/migrations/2024/20240705152938-add-mock-VZW-account.sparql
@@ -58,7 +58,7 @@ INSERT {
      BIND(IRI(CONCAT("http://data.lblod.info/id/account/", ?uuidAccount)) AS ?account)
 
      VALUES ?g {
-        <http://mu.semte.ch/graphs/organizations/3691beca-84ba-40ad-be53-d2b009826f70>
+        <http://mu.semte.ch/graphs/organizations/3e5edbbb-26e0-49f9-9082-55f2297bd73a>
         <http://mu.semte.ch/graphs/public> 
      } 
 }

--- a/config/migrations/2024/20240705152938-add-mock-VZW-account.sparql
+++ b/config/migrations/2024/20240705152938-add-mock-VZW-account.sparql
@@ -1,0 +1,64 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX ns1: <https://data.vlaanderen.be/ns/>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX code: <http://data.vlaanderen.be/id/concept/>
+PREFIX schema: <http://schema.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX act: <http://data.lblod.info/id/concept/activiteit/>
+PREFIX pav: <http://purl.org/pav/>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+# MOCK VZW 
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/organisaties/3e5edbbb-26e0-49f9-9082-55f2297bd73a> a org:Organization ;
+        mu:uuid '3e5edbbb-26e0-49f9-9082-55f2297bd73a';
+        skos:prefLabel "Mock VZW" ;
+        dc:description "Mock VZW for testing" ;
+        adms:identifier <http://data.lblod.info/id/identificatoren/4faddea9-b959-4eed-aa4e-b6ec84b14249>.
+
+    <http://data.lblod.info/id/identificatoren/4faddea9-b959-4eed-aa4e-b6ec84b14249> a adms:Identifier;
+        mu:uuid "4faddea9-b959-4eed-aa4e-b6ec84b14249";
+        skos:notation "V0000001".
+  }
+}
+
+;
+
+INSERT {
+  GRAPH ?g {
+     ?persoon a foaf:Person;
+           mu:uuid ?uuidPersoon;
+           foaf:firstName ?classificatie;
+           foaf:familyName ?naam;
+           foaf:member <http://data.lblod.info/id/organisaties/3e5edbbb-26e0-49f9-9082-55f2297bd73a> ;
+           foaf:account ?account.
+     ?account a foaf:OnlineAccount;
+           mu:uuid ?uuidAccount;
+           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+           ext:sessionRole "SubsidiepuntGebruiker". 
+  }
+} WHERE {
+     <http://data.lblod.info/id/organisaties/3e5edbbb-26e0-49f9-9082-55f2297bd73a> a org:Organization;
+     skos:prefLabel ?naam.
+     BIND(CONCAT(?classificatie, " ", ?naam) as ?volledigeNaam)
+     BIND(MD5(?volledigeNaam) as ?uuidPersoon)
+     BIND(MD5(CONCAT(?volledigeNaam,"ACCOUNT")) as ?uuidAccount)
+     BIND(IRI(CONCAT("http://data.lblod.info/id/persoon/", ?uuidPersoon)) AS ?persoon)
+     BIND(IRI(CONCAT("http://data.lblod.info/id/account/", ?uuidAccount)) AS ?account)
+
+     VALUES ?g {
+        <http://mu.semte.ch/graphs/organizations/3691beca-84ba-40ad-be53-d2b009826f70>
+        <http://mu.semte.ch/graphs/public> 
+     } 
+}

--- a/config/migrations/2024/20240716135216-add-org-type-to-bestuurseenheden.sparql
+++ b/config/migrations/2024/20240716135216-add-org-type-to-bestuurseenheden.sparql
@@ -1,0 +1,10 @@
+INSERT {
+  GRAPH ?g {
+    ?subject a <http://www.w3.org/ns/org#Organization>.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?subject a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>.
+  }
+}

--- a/config/migrations/2024/20240716135216-add-org-type-to-bestuurseenheden.sparql
+++ b/config/migrations/2024/20240716135216-add-org-type-to-bestuurseenheden.sparql
@@ -7,4 +7,5 @@ WHERE {
   GRAPH ?g {
     ?subject a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>.
   }
+  BIND(IRI(STR(?g)) AS ?g)
 }

--- a/config/resources/master-users-domain.lisp
+++ b/config/resources/master-users-domain.lisp
@@ -6,8 +6,8 @@
                 (:rijksregister-nummer :string ,(s-prefix "dct:identifier")))
   :has-many `((account :via ,(s-prefix "foaf:account")
                        :as "account")
-              (organisatie :via ,(s-prefix "foaf:member")
-                              :as "organisaties")
+              (organization :via ,(s-prefix "foaf:member")
+                              :as "organizations")
              )
   :on-path "gebruikers"
 )

--- a/config/resources/master-users-domain.lisp
+++ b/config/resources/master-users-domain.lisp
@@ -6,8 +6,8 @@
                 (:rijksregister-nummer :string ,(s-prefix "dct:identifier")))
   :has-many `((account :via ,(s-prefix "foaf:account")
                        :as "account")
-              (bestuurseenheid :via ,(s-prefix "foaf:member")
-                              :as "bestuurseenheden")
+              (organisatie :via ,(s-prefix "foaf:member")
+                              :as "organisaties")
              )
   :on-path "gebruikers"
 )

--- a/config/resources/organisation.lisp
+++ b/config/resources/organisation.lisp
@@ -1,4 +1,4 @@
-(define-resource organisatie ()
+(define-resource organization ()
   :class (s-prefix "org:Organization")
   :properties `((:name :string ,(s-prefix "skos:prefLabel")))
   :has-one `(
@@ -36,7 +36,7 @@
 ;; ORDER REALLY MATTERS FOR NOW!
 
 ;;"RESHUFFLED" from slave-besluit.lisp
-(define-resource bestuurseenheid (organisatie) ;; Subclass of m8g:PublicOrganisation, which is a subclass of dct:Agent
+(define-resource bestuurseenheid (organization) ;; Subclass of m8g:PublicOrganisation, which is a subclass of dct:Agent
   :class (s-prefix "besluit:Bestuurseenheid")
   :properties `((:naam :string ,(s-prefix "skos:prefLabel"))
                 (:alternatieve-naam :string-set ,(s-prefix "skos:altLabel"))

--- a/config/resources/organisation.lisp
+++ b/config/resources/organisation.lisp
@@ -13,7 +13,7 @@
   :on-path "organizations"
 )
 
-(define-resource organization-classification-codes ()
+(define-resource organization-classification-code ()
   :class (s-prefix "ext:OrganizationClassificationCode")
   :properties `((:label :string ,(s-prefix "skos:prefLabel")))
   :resource-base (s-url "http://data.vlaanderen.be/id/concept/OrganizationClassificationCode/")

--- a/config/resources/organisation.lisp
+++ b/config/resources/organisation.lisp
@@ -2,7 +2,7 @@
   :class (s-prefix "org:Organization")
   :properties `((:naam :string ,(s-prefix "skos:prefLabel")))
   :has-one `(
-            (organization-classification-codes :via ,(s-prefix "org:classification")
+            (organization-classification-code :via ,(s-prefix "org:classification")
                               :as "classificatie"))
   :has-many `(
               (identifier :via ,(s-prefix "adms:identifier")

--- a/config/resources/organisation.lisp
+++ b/config/resources/organisation.lisp
@@ -10,7 +10,7 @@
 
   :resource-base (s-url "http://data.lblod.info/id/organisaties/")
   :features '(include-uri)
-  :on-path "organisaties"
+  :on-path "organizations"
 )
 
 (define-resource organization-classification-codes ()

--- a/config/resources/organisation.lisp
+++ b/config/resources/organisation.lisp
@@ -1,3 +1,34 @@
+(define-resource organisatie ()
+  :class (s-prefix "org:Organization")
+  :properties `((:name :string ,(s-prefix "skos:prefLabel")))
+  :has-one `(
+            (organization-classification-codes :via ,(s-prefix "org:classification")
+                              :as "classificatie"))
+  :has-many `(
+              (identifier :via ,(s-prefix "adms:identifier")
+                              :as "identifiers"))
+
+  :resource-base (s-url "http://data.lblod.info/id/organisaties/")
+  :features '(include-uri)
+  :on-path "organisaties"
+)
+
+(define-resource organization-classification-codes ()
+  :class (s-prefix "ext:OrganizationClassificationCode")
+  :properties `((:label :string ,(s-prefix "skos:prefLabel")))
+  :resource-base (s-url "http://data.vlaanderen.be/id/concept/OrganizationClassificationCode/")
+  :features '(include-uri)
+  :on-path "organization-classification-codes"
+)
+
+(define-resource identifier ()
+  :class (s-prefix "adms:Identifier")
+  :properties `((:id-name :string ,(s-prefix "skos:notation")))
+  :resource-base (s-url "http://data.lblod.info/id/identificatoren/")
+  :features '(include-uri)
+  :on-path "identifiers"
+)
+
 ;; re-shuffle declaration of files, because
 ;; mu-resource 1.21.0 is sensible when files
 ;; are declared vs loaded the class hierarchy
@@ -5,7 +36,7 @@
 ;; ORDER REALLY MATTERS FOR NOW!
 
 ;;"RESHUFFLED" from slave-besluit.lisp
-(define-resource bestuurseenheid () ;; Subclass of m8g:PublicOrganisation, which is a subclass of dct:Agent
+(define-resource bestuurseenheid (organisatie) ;; Subclass of m8g:PublicOrganisation, which is a subclass of dct:Agent
   :class (s-prefix "besluit:Bestuurseenheid")
   :properties `((:naam :string ,(s-prefix "skos:prefLabel"))
                 (:alternatieve-naam :string-set ,(s-prefix "skos:altLabel"))
@@ -32,3 +63,4 @@
   :features '(include-uri)
   :on-path "bestuurseenheden"
 )
+

--- a/config/resources/organisation.lisp
+++ b/config/resources/organisation.lisp
@@ -1,6 +1,6 @@
 (define-resource organization ()
   :class (s-prefix "org:Organization")
-  :properties `((:name :string ,(s-prefix "skos:prefLabel")))
+  :properties `((:naam :string ,(s-prefix "skos:prefLabel")))
   :has-one `(
             (organization-classification-codes :via ,(s-prefix "org:classification")
                               :as "classificatie"))


### PR DESCRIPTION
## ID
DGS-231

## Description
This PR enables us to also mocklogin as organizations instead of just bestuurseenheden.

Changes:
- dispatcher
- resources
- mocklogin service
- frontend

## Type of change

 - [ ] Bug fix
 - [ ] New feature
 - [x] Breaking change
 - [ ] Maintanance

## How to setup
- Checkout this PR
- replace mock-login image by `aatauil/mock-login:verenigingen-0.0.2`
- replace frontend image by `aatauil/frontend-subsidiepunt:verenigingen`

## How to test
Add the following environment variable to mocklogin service:
```   
environment:
  GROUP_TYPE: "http://www.w3.org/ns/org#Organization"
```
Login with using mock-login. Try any bestuurseenheid , check if it still works
Then back to mock-login. Type VZW and choose "mock VZW". (this is an organization) 
Check if it works. 

