### PR TITLE
Feature/subsidiedatabank flow

### DIFF
--- a/config/delta-producer/subsidies/export.json
+++ b/config/delta-producer/subsidies/export.json
@@ -6,6 +6,33 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://purl.org/dc/terms/created",
         "http://purl.org/dc/terms/modified",
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://purl.org/dc/terms/description",
+        "http://www.w3.org/ns/org#classification",
+        "http://www.w3.org/ns/adms#identifier"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
+      "type": "http://www.w3.org/ns/org#Organization"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2004/02/skos/core#notation"
+      ],
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
+      "type": "http://www.w3.org/ns/adms#Identifier"
+    },
+    {
+      "properties": [
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://purl.org/dc/terms/created",
+        "http://purl.org/dc/terms/modified",
         "http://www.w3.org/2007/uwa/context/common.owl#active",
         "http://www.w3.org/ns/adms#status",
         "http://data.vlaanderen.be/ns/transactie#isInstantieVan",


### PR DESCRIPTION
## ID
DGS-351

## Description
This PR makes sure newly created organizations (specifically economische actoren) flow through to subsidiedatatabank when created

## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
Setup consumer producer flow subsidiedatabank -> subsidiepunt

## How to test
Login with unknown organization (or create one using a migration) and make sure it gets consumed by subsidiedatabank