### PR TITLE
Added migration for cleanup-job and db-cleanup-service

### DIFF
--- a/config/migrations/2024/20240808165440-db-cleanup-job-fix-types-fietssubsidies.sparql
+++ b/config/migrations/2024/20240808165440-db-cleanup-job-fix-types-fietssubsidies.sparql
@@ -1,0 +1,365 @@
+PREFIX cleanup: <http://mu.semte.ch/vocabularies/ext/cleanup/>
+PREFIX mu:      <http://mu.semte.ch/vocabularies/core/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/job/id/bdb6425e-a1ef-42e7-b6a6-495e8d462536> a cleanup:Job;
+      mu:uuid "bdb6425e-a1ef-42e7-b6a6-495e8d462536";
+      dcterms:title "Compensating missing rdf:Type on some formNodes in some subsidy forms";
+      cleanup:randomQuery """
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/accountability-note-upload/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/accountabilityNoteUpload> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/ukraine-nooddorpen/accountability-proof/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/accountabilityProof> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/ukraine-nooddorpen/accountability-summary/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/accountabilitySummary> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/award-report-upload/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/awardReportUpload> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-four/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveFour> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-one/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveOne> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-three/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveThree> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/contact-tracing/contact-and-source-tracking-objective-two/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/contactAndSourceTrackingObjectiveTwo> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?contactPoint <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/ContactPoint> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?s <http://schema.org/contactPoint> ?contactPoint .
+            ?contactPoint ?p_c ?o_c .
+          }
+
+          FILTER NOT EXISTS {
+            ?contactPoint <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/decision-upload/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/decisionUpload> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/invoice-upload/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/invoiceUpload> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-costs-upload/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/justificationCostsUpload> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/justification-expropriations-upload/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/justificationExpropriationsUpload> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/picturesUpload> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?politicalReferenceContactPoint <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://mu.semte.ch/vocabularies/ext/PoliticalReferenceContactPoint> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://mu.semte.ch/vocabularies/ext/politicalReferenceContactPoint> ?politicalReferenceContactPoint .
+            ?politicalReferenceContactPoint ?p_p ?o_p .
+          }
+
+          FILTER NOT EXISTS {
+            ?politicalReferenceContactPoint <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/reportUpload> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/climate/signed-pact/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/signedPact> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/urban-renewal/urban-renewal-application-form/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/urbanRenewalApplicationForm> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/urban-renewal/urban-renewal-attachments/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/urbanRenewalAttachments> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/BankAccount> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://schema.org/bankAccount> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/climate/attachment/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/attachment> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        ;
+        INSERT {
+          GRAPH ?g {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://lblod.data.gift/vocabularies/subsidie/climate/attachment/FormData> .
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ?applicationForm <http://lblod.data.gift/vocabularies/subsidie/attachmentLEKPReport> ?formData .
+            ?formData ?p_f ?o_f .
+          }
+
+          FILTER NOT EXISTS {
+            ?formData <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+          }
+        }
+        """;
+      cleanup:cronPattern "0 21 * * *". # Runs daily at 21.00
+    }
+  }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,6 +38,8 @@ services:
     restart: "no"
   resource:
     restart: "no"
+  db-cleanup:
+    restart: "no"
   login:
     restart: "no"
   file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,12 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  db-cleanup:
+    image: lblod/db-cleanup-service:0.5.0-rc.5
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   login:
     image: lblod/acmidm-login-service:0.11.0
     environment:


### PR DESCRIPTION
## ID
DGS-347

## Description
Introduces the db-cleanup service + the periodic job executing the migration to compensate the missing types for fietssubsidies.
See also: https://github.com/lblod/db-cleanup-service
Note: used an `rc` build since there were still a couple of improvements to do. But should be fine to use like that.
## Type of change

 - [ ] Bug fix
 - [ x] New feature
 - [ ] Breaking change
 - [x ] Maintanance

## How to setup
Get the PR and `drc up -d; drc logs -f --tail=200 db-cleanup`.

## How to test
Either you wait for the job to kick in, which should be at 21.00 OR you trigger it manually with `drc exec db-cleanup wget --post-data='' http://localhost/cleanup`. 
