### PR TITLE
Remove duplicate URI for IBEG

### DIFF
--- a/config/migrations/2024/20240905112707-remove-duplicate-uri-for-ibeg.sparql
+++ b/config/migrations/2024/20240905112707-remove-duplicate-uri-for-ibeg.sparql
@@ -1,0 +1,104 @@
+# Remove wrong URI + reverse properties
+
+DELETE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/bestuurseenheden/2559a855-a1c9-489d-964b-1d3c9bada85b> ?p ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/bestuurseenheden/2559a855-a1c9-489d-964b-1d3c9bada85b> ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p <http://data.lblod.info/id/bestuurseenheden/2559a855-a1c9-489d-964b-1d3c9bada85b> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s ?p <http://data.lblod.info/id/bestuurseenheden/2559a855-a1c9-489d-964b-1d3c9bada85b> .
+  }
+}
+
+;
+
+# Remove person and account attached to the wrong URI
+
+DELETE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/persoon/d7ab3f6ceef06a8095e38db10aaec419> ?p_person ?o_person .
+  }
+
+  GRAPH ?h {
+    <http://data.lblod.info/id/account/c1dfc1259769babd01d9b7b2fbd45b72> ?p_account ?o_account .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/persoon/d7ab3f6ceef06a8095e38db10aaec419> ?p_person ?o_person .
+  }
+
+  GRAPH ?h {
+    <http://data.lblod.info/id/account/c1dfc1259769babd01d9b7b2fbd45b72> ?p_account ?o_account .
+  }
+}
+
+;
+
+# Delete old bestuursorganen
+
+DELETE {
+  GRAPH ?g {
+    ?bestuursorganen ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?bestuursorganen {
+    <http://data.lblod.info/id/bestuursorganen/65a0c535-a6e0-4229-b565-5e93df72acf2>
+    <http://data.lblod.info/id/bestuursorganen/21f0b18a-7a9f-4777-84c2-7f53313e3ad9>
+    <http://data.lblod.info/id/bestuursorganen/9285a0c5-ec17-4d89-83b1-5b8a96a05096>
+    <http://data.lblod.info/id/bestuursorganen/d909e52a8215a7423082a7a800da7f171a713022e0c4475e12dcd44906982f12>
+    <http://data.lblod.info/id/bestuursorganen/2e6b537b-b486-4456-aab6-c421a85cf55d>
+  }
+
+  GRAPH ?g {
+    ?bestuursorganen ?p ?o .
+  }
+}
+
+;
+
+# Delete old bestuursorganen in tijd
+
+DELETE {
+  GRAPH ?g {
+    ?bestuursorgaanInTijd ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?bestuursorgaanInTijd {
+    <http://data.lblod.info/id/bestuursorganen/7264b6d0-f123-493a-8fe2-4802b5be1aec>
+    <http://data.lblod.info/id/bestuursorganen/8bcdcde8-edeb-4cb5-aae3-0c147d631abc>
+    <http://data.lblod.info/id/bestuursorganen/7ac7d2cb-5fc6-4f36-a6dd-8813cd3e6f3a>
+    <http://data.lblod.info/id/bestuursorganen/b2bea1a43457ea68652f2f7d9b3fa396e952b7fb80d782fcc8660fea42d0c5d5>
+    <http://data.lblod.info/id/bestuursorganen/2a96151e-cbf1-42f6-ac5d-3f9780b3667d>
+  }
+
+  GRAPH ?g {
+    ?bestuursorgaanInTijd ?p ?o .
+  }
+}
+
+;
+
+# Clear wrong organization graph
+CLEAR GRAPH <http://mu.semte.ch/graphs/organizations/2559a855-a1c9-489d-964b-1d3c9bada85b>
+
+;
+
+# Clear wrong subsidies graph
+CLEAR GRAPH <http://mu.semte.ch/graphs/organizations/2559a855-a1c9-489d-964b-1d3c9bada85b/LoketLB-subsidies>


### PR DESCRIPTION
## ID

DL-5770

## Description

This PR adds a migration to remove a duplicate organization URI, its properties + reverse properties and its connected bestuursorganen and bestuursorganen in tijd.

## Type of change

 - [X] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup

Run:
* `docker compose restart migrations`
* `docker compose restart resource cache`

for the change to kick in.

## How to test

Before running the migration, go to `/mock-login` and paste the following: `Intercommunale van Brabant voor Electriciteit`.

You should see two names:
* **Dienstverlenende vereniging Maatschappelijke Naam: Intercommunale van Brabant voor Electriciteit**
* **Opdrachthoudende vereniging IBEG**

After running the migration, only **Opdrachthoudende vereniging IBEG** should remain.