### PR TITLE
Fix some issues with fietsinfrastructuur migrations

### DIFF
--- a/config/migrations/2024/20241113101105-fusies/20241113110005-pajottegem.sparql
+++ b/config/migrations/2024/20241113101105-fusies/20241113110005-pajottegem.sparql
@@ -4,7 +4,7 @@ PREFIX schema:     <http://schema.org/>
 
 # CONSUMPTION TRIPLES
 INSERT {
-  GRAPH <http://mu.semte.ch/graphs/organizations/1ca65d65-54ff-4b44-b750-bd70c91191af/SubsidiepuntGebruiker> { # Pajottegem"
+  GRAPH <http://mu.semte.ch/graphs/organizations/add1e4eb-9ec7-4ea6-af82-335aa76b7d48/SubsidiepuntGebruiker> { # Pajottegem"
     ?consumption a <http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelConsumptie>;
       <http://mu.semte.ch/vocabularies/core/uuid> ?uuid;
       <http://purl.org/dc/terms/created> ?created;
@@ -66,7 +66,7 @@ WHERE {
 
 # Get Data From UploadFields
 INSERT {
-  GRAPH <http://mu.semte.ch/graphs/organizations/1ca65d65-54ff-4b44-b750-bd70c91191af/SubsidiepuntGebruiker> { # Pajottegem
+  GRAPH <http://mu.semte.ch/graphs/organizations/add1e4eb-9ec7-4ea6-af82-335aa76b7d48/SubsidiepuntGebruiker> { # Pajottegem
     ?step ?uploadPredicate ?formData. 
     ?formData a ?type.
     ?formData ?formDataPredicate ?fileDataObject.
@@ -118,7 +118,7 @@ WHERE {
 
 # BankAccount & Contactpoint
 INSERT {
-  GRAPH <http://mu.semte.ch/graphs/organizations/1ca65d65-54ff-4b44-b750-bd70c91191af/SubsidiepuntGebruiker> { # Pajottegem
+  GRAPH <http://mu.semte.ch/graphs/organizations/add1e4eb-9ec7-4ea6-af82-335aa76b7d48/SubsidiepuntGebruiker> { # Pajottegem
     ?step <http://schema.org/contactPoint> ?contactPoint.
     ?contactPoint ?contactPointPredicate ?contactPointSubject.
 
@@ -153,7 +153,7 @@ WHERE {
 # Data Tables
 
 INSERT {
-  GRAPH <http://mu.semte.ch/graphs/organizations/1ca65d65-54ff-4b44-b750-bd70c91191af/SubsidiepuntGebruiker> { # Pajottegem
+  GRAPH <http://mu.semte.ch/graphs/organizations/add1e4eb-9ec7-4ea6-af82-335aa76b7d48/SubsidiepuntGebruiker> { # Pajottegem
     ?step ?tablePredicate ?table.
     ?table a ?tableType;
       <http://mu.semte.ch/vocabularies/core/uuid> ?tableUuid;

--- a/config/migrations/2024/20241113101105-fusies/20241113110010-merelbeke-melle.sparql
+++ b/config/migrations/2024/20241113101105-fusies/20241113110010-merelbeke-melle.sparql
@@ -4,7 +4,7 @@ PREFIX schema:     <http://schema.org/>
 
 # CONSUMPTION TRIPLES
 INSERT {
-  GRAPH <http://mu.semte.ch/graphs/organizations/5d94b2fd-60ee-4e56-a1f0-a586d596adf6/SubsidiepuntGebruiker> { # Merelbeke-melle
+  GRAPH <http://mu.semte.ch/graphs/organizations/b8bb293d-aa22-4b43-bda4-0b6af76e9493/SubsidiepuntGebruiker> { # Merelbeke-melle
     ?consumption a <http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelConsumptie>;
       <http://mu.semte.ch/vocabularies/core/uuid> ?uuid;
       <http://purl.org/dc/terms/created> ?created;
@@ -65,7 +65,7 @@ WHERE {
 
 # Get Data From UploadFields
 INSERT {
-  GRAPH <http://mu.semte.ch/graphs/organizations/5d94b2fd-60ee-4e56-a1f0-a586d596adf6/SubsidiepuntGebruiker> { # Merelbeke-melle
+  GRAPH <http://mu.semte.ch/graphs/organizations/b8bb293d-aa22-4b43-bda4-0b6af76e9493/SubsidiepuntGebruiker> { # Merelbeke-melle
     ?step ?uploadPredicate ?formData. 
     ?formData a ?type.
     ?formData ?formDataPredicate ?fileDataObject.
@@ -116,7 +116,7 @@ WHERE {
 
 # BankAccount & Contactpoint
 INSERT {
-  GRAPH <http://mu.semte.ch/graphs/organizations/5d94b2fd-60ee-4e56-a1f0-a586d596adf6/SubsidiepuntGebruiker> { # Merelbeke-melle
+  GRAPH <http://mu.semte.ch/graphs/organizations/b8bb293d-aa22-4b43-bda4-0b6af76e9493/SubsidiepuntGebruiker> { # Merelbeke-melle
     ?step <http://schema.org/contactPoint> ?contactPoint.
     ?contactPoint ?contactPointPredicate ?contactPointSubject.
 
@@ -150,7 +150,7 @@ WHERE {
 # Data Tables
 
 INSERT {
-  GRAPH <http://mu.semte.ch/graphs/organizations/5d94b2fd-60ee-4e56-a1f0-a586d596adf6/SubsidiepuntGebruiker> { # Merelbeke-melle
+  GRAPH <http://mu.semte.ch/graphs/organizations/b8bb293d-aa22-4b43-bda4-0b6af76e9493/SubsidiepuntGebruiker> { # Merelbeke-melle
     ?step ?tablePredicate ?table.
     ?table a ?tableType;
       <http://mu.semte.ch/vocabularies/core/uuid> ?tableUuid;


### PR DESCRIPTION
## ID
DGS-455

## Description
no mock-login for 'Tongeren-Borgloon' + 'Tessenderlo-Ham'
incorrect submissions migrated to 'Nazareth-De Pinte' from 'Galmaarden', 'Gooik' & 'Herne'
no migration to 'Pajottegem' + 'Merelbeke-Melle'

## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Maintanance
