### PR TITLE
Add Impersonation to subsidiepunt

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -51,6 +51,27 @@ defmodule Acl.UserGroups.Config do
       }
   end
 
+  defp is_admin() do
+    %AccessByQuery{
+      vars: [],
+      query: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      SELECT DISTINCT ?session_role WHERE {
+        VALUES ?session_role {
+          \"Subsidiepunt-admin\"
+        }
+        VALUES ?session_id {
+          <SESSION_ID>
+        }
+        {
+          ?session_id ext:sessionRole ?session_role .
+        } UNION {
+          ?session_id ext:originalSessionRole ?session_role .
+        }
+      }
+      LIMIT 1"
+      }
+  end
+
   def user_groups do
     # These elements are walked from top to bottom.  Each of them may
     # alter the quads to which the current query applies.  Quads are
@@ -105,9 +126,13 @@ defmodule Acl.UserGroups.Config do
           vars: ["session_group"],
           query: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
                   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-                  SELECT ?session_group ?session_role WHERE {
-                    <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group.
-                    }" },
+                  SELECT DISTINCT ?session_group WHERE {
+                    {
+                      <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group.
+                    } UNION {
+                      <SESSION_ID> ext:originalSessionGroup/mu:uuid ?session_group.
+                    }
+                  }" },
         graphs: [ %GraphSpec{
                     graph: "http://mu.semte.ch/graphs/organizations/",
                     constraint: %ResourceConstraint{
@@ -116,7 +141,6 @@ defmodule Acl.UserGroups.Config do
                         "http://xmlns.com/foaf/0.1/OnlineAccount",
                         "http://www.w3.org/ns/adms#Identifier",
                       ] } } ] },
-
       # // SUBSIDIES
       %GroupSpec{
         name: "o-subs-rwf",
@@ -156,22 +180,19 @@ defmodule Acl.UserGroups.Config do
                               "http://data.europa.eu/m8g/playsRole"
                             ] } } } ] },
 
-      # // LOKETADMIN
-        %GroupSpec{
-          name: "o-admin-rwf",
-          useage: [:read, :write, :read_for_write],
-          access: access_by_role( "LoketAdmin" ),
-          graphs: [ %GraphSpec{
-                      graph: "http://mu.semte.ch/graphs/organizations/",
-                      constraint: %ResourceConstraint{
-                        resource_types: [
-                          "http://lblod.data.gift/vocabularies/reporting/Report",
-                          "http://vocab.deri.ie/cogs#Job",
-                          "http://open-services.net/ns/core#Error",
-                          "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer",
-                          "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
-                          "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer"
-                        ] } } ] },
+      %GroupSpec{
+        name: "o-admin-sessions-rwf",
+        useage: [:read, :write, :read_for_write],
+        access: is_admin(),
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/sessions",
+            constraint: %ResourceFormatConstraint{
+              resource_prefix: "http://mu.semte.ch/sessions/"
+            }
+          },
+        ]
+      },
 
       %GroupSpec{
         name: "o-persons-sensitive-deltas-rwf",

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -57,7 +57,7 @@ defmodule Acl.UserGroups.Config do
       query: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       SELECT DISTINCT ?session_role WHERE {
         VALUES ?session_role {
-          \"Subsidiepunt-admin\"
+          \"SubsidiepuntAdmin\"
         }
         VALUES ?session_id {
           <SESSION_ID>
@@ -178,8 +178,10 @@ defmodule Acl.UserGroups.Config do
                           predicates: %NoPredicates{
                             except: [
                               "http://data.europa.eu/m8g/playsRole"
-                            ] } } } ] },
+                            ] } } } ]
+      },
 
+      # // Admin users
       %GroupSpec{
         name: "o-admin-sessions-rwf",
         useage: [:read, :write, :read_for_write],
@@ -189,6 +191,21 @@ defmodule Acl.UserGroups.Config do
             graph: "http://mu.semte.ch/graphs/sessions",
             constraint: %ResourceFormatConstraint{
               resource_prefix: "http://mu.semte.ch/sessions/"
+            }
+          },
+        ]
+      },
+      %GroupSpec{
+        name: "o-admin-sessions-rwf",
+        useage: [:read_for_write],
+        access: is_admin(),
+        graphs: [
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/public",
+            constraint: %ResourceConstraint {
+              resource_types: [
+                "http://xmlns.com/foaf/0.1/OnlineAccount"
+                ],
             }
           },
         ]

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -12,6 +12,11 @@ defmodule Dispatcher do
   #   forward conn, path, "http://resource/themes/"
   # end
 
+
+  match "/impersonations/*path" do
+    forward conn, path, "http://impersonation/impersonations/"
+  end
+
   match "/organizations/*path" do
     forward conn, path, "http://cache/organizations/"
   end

--- a/config/migrations/2025/20250512214331-add-admin-role-to-abb.sparql
+++ b/config/migrations/2025/20250512214331-add-admin-role-to-abb.sparql
@@ -1,6 +1,6 @@
 INSERT {
   GRAPH ?g {
-    ?mock <http://mu.semte.ch/vocabularies/ext/sessionRole> "Subsidiepunt-admin" .
+    ?mock <http://mu.semte.ch/vocabularies/ext/sessionRole> "SubsidiepuntAdmin" .
   }
 }
 WHERE {

--- a/config/migrations/2025/20250512214331-add-admin-role-to-abb.sparql
+++ b/config/migrations/2025/20250512214331-add-admin-role-to-abb.sparql
@@ -1,0 +1,14 @@
+INSERT {
+  GRAPH ?g {
+    ?mock <http://mu.semte.ch/vocabularies/ext/sessionRole> "Subsidiepunt-admin" .
+  }
+}
+WHERE {
+  VALUES ?mock {
+    <http://data.lblod.info/id/account/3a91ff60-07c1-4136-ac5e-55cf401e0956>
+  }
+
+  GRAPH ?g {
+    ?mock <http://mu.semte.ch/vocabularies/ext/sessionRole> ?role .
+  }
+}

--- a/config/resources/master-users-domain.lisp
+++ b/config/resources/master-users-domain.lisp
@@ -16,6 +16,7 @@
   :class (s-prefix "foaf:OnlineAccount")
   :resource-base (s-url "http://data.lblod.info/id/account/")
   :properties `((:provider :via ,(s-prefix "foaf:accountServiceHomepage"))
+                (:roles :string-set ,(s-prefix "ext:sessionRole"))
                 (:vo-id :via ,(s-prefix "dct:identifier")))
   :has-one `((gebruiker :via ,(s-prefix "foaf:account")
                          :inverse t

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,8 @@ services:
     image: lblod/mock-login-service:0.7.0
     environment:
       GROUP_TYPE: "http://www.w3.org/ns/org#Organization"
+  impersonation:
+    restart: "no"
   frontend:
     restart: "no"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,12 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  impersonation:
+    image: lblod/impersonation-service:0.2.0
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   sink:
     image: nginx:1.15.2
     volumes:


### PR DESCRIPTION
## ID
DGS-520

## Description
This adds the impersonation service and config to subsidiepunt

## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
Setup as usual, make sure migrations ran correctly. Also pull frontend-subsidiepunt and checkout branch/impersionation. then proxy to localhost:90 by default

## How to test
-Login to a bestuurseenheid like hasselt. Check if everything is "normal".

-Then logout and login to "agentschap binnenlands bestuur". You should see the impersonation button top right. imporsonate a regular bestuurseenheid. Check if everything works as "normal". 

-Then change simulation to a verengiging search for "mock vzw" and simulate that organization. Check if everything works as "normal". Thats it 
