### PR TITLE
update the projectnaam field to be a textarea size

### DIFF
--- a/config/subsidy-application-management/forms/urban-renewal-concept-subsidy/application/versions/20250409094018-oproep-2025/form.ttl
+++ b/config/subsidy-application-management/forms/urban-renewal-concept-subsidy/application/versions/20250409094018-oproep-2025/form.ttl
@@ -261,12 +261,18 @@ ext:projectSection
         sh:order          1 ;
         sh:path           lblodSubsidie:projectNaam ;
         form:validations
+                          [ a                 form:MaxLength ;
+                            form:grouping     form:MatchEvery ;
+                            form:max          "150" ;
+                            sh:resultMessage  "Max. karakters overschreden." ;
+                            sh:path            lblodSubsidie:projectNaam
+                          ],
                           [ a                 form:RequiredConstraint ;
                             form:grouping     form:Bag ;
                             sh:resultMessage  "Dit veld is verplicht." ;
                             sh:path           lblodSubsidie:projectNaam
                           ] ;
-        form:displayType  displayTypes:defaultInput ;
+        form:displayType  displayTypes:textArea ;
         sh:group       ext:projectSection .
 
   ##########################################################

--- a/config/subsidy-application-management/forms/urban-renewal/application-phase2/versions/20250304132142-oproep-2025/form.ttl
+++ b/config/subsidy-application-management/forms/urban-renewal/application-phase2/versions/20250304132142-oproep-2025/form.ttl
@@ -278,7 +278,7 @@ ext:projectNameSection
                           sh:resultMessage  "Dit veld is verplicht." ;
                           sh:path           lblodSubsidie:projectName            
                         ] ;
-      form:displayType  displayTypes:defaultInput ;
+      form:displayType  displayTypes:textArea ;
       sh:group       ext:projectNameSection .
 
 


### PR DESCRIPTION
## ID
DGS-531

## Description
This updates the projectnaam field to be of type textarea so that it does not get cut off. This for both stadsvernieuwing subsidies

## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance
