### PR TITLE
Feature/subsidiedatabank merger

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -196,6 +196,36 @@ defmodule Acl.UserGroups.Config do
           },
         ]
       },
+
+      %GroupSpec{
+        name: "o-admin-publication-read",
+        useage: [:read],
+        access: is_admin(),
+        graphs: [
+          %GraphSpec{
+            graph: "http://redpencil.data.gift/id/deltas/producer/loket-subsidies",
+            constraint: %ResourceConstraint {
+               resource_types: [
+                "http://lblod.data.gift/vocabularies/subsidie/ApplicationForm",
+                "http://data.vlaanderen.be/ns/subsidie#SubsidiemaatregelConsumptie",
+                "http://data.vlaanderen.be/ns/subsidie#Aanvraag",
+                "http://schema.org/MonetaryAmount",
+                "http://data.europa.eu/m8g/Participation",
+                "http://schema.org/BankAccount",
+                "https://www.gleif.org/ontology/Base/Period",
+                "http://data.europa.eu/m8g/PeriodOfTime",
+                "http://lblod.data.gift/vocabularies/subsidie/ApplicationFormTable",
+                "http://mu.semte.ch/vocabularies/ext/ApplicationFormEntry",
+                "http://lblod.data.gift/vocabularies/subsidie/EngagementTable",
+                "http://mu.semte.ch/vocabularies/ext/EngagementEntry",
+                "http://schema.org/ContactPoint",
+                "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
+              ]
+            }
+          },
+        ]
+      },
+
       %GroupSpec{
         name: "o-admin-sessions-rwf",
         useage: [:read_for_write],

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -68,10 +68,6 @@ services:
     restart: "no"
   subsidy-application-flow-management:
     restart: "no"
-  publication-triplestore:
-    restart: "no"
-    ports:
-      - "8891:8890"
   delta-producer-report-generator:
     restart: "no"
   delta-producer-dump-file-publisher:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,17 +220,6 @@ services:
   ################################################################################
   # DELTA GENERAL
   ################################################################################
-  publication-triplestore:
-    image: redpencil/virtuoso:1.2.0-rc.1
-    environment:
-      SPARQL_UPDATE: "true"
-      DEFAULT_GRAPH: "http://mu.semte.ch/application"
-    volumes:
-      - ./data/publication-triplestore:/data
-      - ./config/publication-triple-store/virtuoso.ini:/data/virtuoso.ini
-      - ./config/publication-triple-store/:/opt/virtuoso-scripts
-    restart: always
-    logging: *default-logging
   delta-producer-report-generator:
     image: lblod/delta-producer-report-generator:0.4.0
     volumes:
@@ -300,8 +289,6 @@ services:
       SERVE_DELTA_FILES: "true"
       DELTA_INTERVAL_MS: 10000
       PRETTY_PRINT_DIFF_JSON: "true"
-      PUBLICATION_VIRTUOSO_ENDPOINT: "http://publication-triplestore:8890/sparql"
-      PUBLICATION_MU_AUTH_ENDPOINT: "http://publication-triplestore:8890/sparql"
       SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: "404"
       PUBLISHER_URI: "http://data.lblod.info/services/delta-producer-publication-graph-maintainer-subsidies"
       FILES_GRAPH: "http://redpencil.data.gift/id/deltas/producer/subsidies-deltas"


### PR DESCRIPTION
## ID
DGS-

## Description
In context of the subsidiedatabank merger, this PR fuses publication-triplestore with virtuoso-triplestore to make the graph available. Then gives access to ABB users to access the publication-graph that is now available on the virtuoso-triplestore

## Type of change

 - [ ] Bug fix
 - [X] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
- Best to pull in QA
- re-trigger initial-sync override.yml. (might need to remove initial sync job in db to make this work)
```
  delta-producer-background-jobs-initiator-subsidies:
    environment:
      START_INITIAL_SYNC: 'true'
```
- When done, run frontend-subsidieDATABANK. Proxy to subsidiepunt backend
- Login and check if all data is there
! important, most likely filters do not work yet (different ticket)
