### PR TITLE
Fix berlare fietsinfrastructuur skipped steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+- Reopen fietsinfrastructuur skipped steps for berlare
+### Deploy instructions
+`drc restart migrations cache resource`
 # 2.17.0
 - New subsidy train-the-trainer
 ### Deploy instructions

--- a/config/migrations/2025/20250912141418-fietsinfrastructuur-subsidie/20251001094247-fix-berlare-middle-steps.sparql
+++ b/config/migrations/2025/20250912141418-fietsinfrastructuur-subsidie/20251001094247-fix-berlare-middle-steps.sparql
@@ -1,0 +1,46 @@
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+# Berlare F4D235
+DELETE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/subsidy-measure-consumptions/6218EE615DA26800080000E8> adms:status ?oldConsumptionStatus .
+    <http://data.lblod.info/id/application-forms/68B84BCB132744F7B1F85D79> adms:status ?oldFormStatus .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    <http://data.lblod.info/id/subsidy-measure-consumptions/6218EE615DA26800080000E8> adms:status <http://lblod.data.gift/concepts/c849ca98-455d-4f31-9e95-a3d9d06e4497> ; # ACTIVE status
+    <http://www.w3.org/2007/uwa/context/common.owl#active> <http://lblod.data.info/id/subsidie-application-flow-steps/75aa0af5-21e1-44c4-96e9-7f7f013bd1cc>. # Set to middle step
+    <http://data.lblod.info/id/application-forms/68B84BCB132744F7B1F85D79> adms:status <http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd> . # CONCEPT
+
+  }
+}
+WHERE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/subsidy-measure-consumptions/6218EE615DA26800080000E8> adms:status ?oldConsumptionStatus .
+    <http://data.lblod.info/id/application-forms/68B84BCB132744F7B1F85D79> adms:status ?oldFormStatus .
+  }
+}
+;
+
+# Berlare D1C58F
+DELETE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/subsidy-measure-consumptions/6218FAD95DA2680008000124> adms:status ?oldConsumptionStatus .
+    <http://data.lblod.info/id/application-forms/68B8502C132744F7B1F85D7A> adms:status ?oldFormStatus .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    <http://data.lblod.info/id/subsidy-measure-consumptions/6218FAD95DA2680008000124> adms:status <http://lblod.data.gift/concepts/c849ca98-455d-4f31-9e95-a3d9d06e4497> ; # ACTIVE status
+    <http://www.w3.org/2007/uwa/context/common.owl#active> <http://lblod.data.info/id/subsidie-application-flow-steps/75aa0af5-21e1-44c4-96e9-7f7f013bd1cc>. # Set to middle step
+    <http://data.lblod.info/id/application-forms/68B8502C132744F7B1F85D7A> adms:status <http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd> . # CONCEPT
+
+  }
+}
+WHERE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/subsidy-measure-consumptions/6218FAD95DA2680008000124> adms:status ?oldConsumptionStatus .
+    <http://data.lblod.info/id/application-forms/68B8502C132744F7B1F85D7A> adms:status ?oldFormStatus .
+  }
+}


### PR DESCRIPTION
## ID
DGS-586

## Description

Re-open skipped middle steps of berlare for fietsinfrastructuur subsidies.

## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup and test

Rsync prod data, login as gemeente berlare

Before running migration, the middle steps are skipped (see DGS-580). After running the migration the subsidie is open again, and the middle step is the one active. Re-submit middle and last step to submit again

