### PR TITLE
[DGS-623] Fietsinfrastructuur subsidy - step 4 - bevestiging voorschot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
-
+## unreleased
+- Add fietssubsidy step 4 and set active 
+### Deploy notes
+!important -> only deploy AFTER 30 april 23h59!
+```
+drc restart subsidy-applications-management subsidy-application-flow-management cache resource
+```
 ## 2.25.0 (2026-04-15)
 - Frontend [v1.18.0](https://github.com/lblod/frontend-subsidiepunt/blob/0694d1f2a652f2173ec557882096854210783c67/CHANGELOG.md#v1180-2026-04-08)
 

--- a/config/migrations/2026/20260113114731-fietsinstrastructuur/20260416130724-add-new-step-4-bevestiging-voorschot.sparql
+++ b/config/migrations/2026/20260113114731-fietsinstrastructuur/20260416130724-add-new-step-4-bevestiging-voorschot.sparql
@@ -1,0 +1,43 @@
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX subsidie: <http://data.vlaanderen.be/ns/subsidie#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX qb: <http://purl.org/linked-data/cube#>
+PREFIX cpsv: <http://purl.org/vocab/cpsv#>
+PREFIX xkos: <http://rdf-vocabulary.ddialliance.org/xkos#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX common: <http://www.w3.org/2007/uwa/context/common.owl#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # add follows reference to the subsidy measure offer (fietsinfrastructuur subsidy)
+    <http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2> cpsv:follows <http://data.lblod.info/id/subsidy-procedural-steps/1e712857-b865-4b91-b125-846c4650544a> .
+    
+     # add link from subsidy-measure-offer-series to subsidy-procedural-step
+    <http://lblod.data.gift/concepts/2e77f4ea-05f6-4771-ae4b-8cee72d2459f> lblodSubsidie:heeftSubsidieprocedurestap <http://data.lblod.info/id/subsidy-procedural-steps/1e712857-b865-4b91-b125-846c4650544a>.
+
+    # Create new subsidy-procedural-step
+    <http://data.lblod.info/id/subsidy-procedural-steps/1e712857-b865-4b91-b125-846c4650544a> a subsidie:Subsidieprocedurestap;
+      mu:uuid "1e712857-b865-4b91-b125-846c4650544a";
+      dct:description """Bevestiging voorschot""";
+      subsidie:Subsidieprocedurestap.type <http://lblod.data.gift/concepts/ee855aae-eb10-44aa-ae01-38c4f6cca0f6>;
+      mobiliteit:periode <http://data.lblod.info/id/periodes/130eebea-a1ac-411a-80fc-bb88857c0861>.
+
+    # Create new subsidie-application-flow-step
+    <http://data.lblod.info/id/subsidie-application-flow-steps/e78d8615-6595-4f29-bea6-49e26e6696bd> a lblodSubsidie:ApplicationStep;
+      mu:uuid "e78d8615-6595-4f29-bea6-49e26e6696bd";
+      qb:order 3;
+      xkos:previous <http://lblod.data.info/id/subsidie-application-flow-steps/ad08beb8-b4a5-4a0e-ae99-1174b3b47d47>;
+      dct:references <http://data.lblod.info/id/subsidy-procedural-steps/1e712857-b865-4b91-b125-846c4650544a>;
+      dct:isPartOf <http://lblod.data.info/id/subsidie-application-flows/26e0050a-3c55-4e54-8212-82b77280b17a>, <http://lblod.data.info/id/subsidie-application-flows/1a7fb92ca5e7a948c687bda5754233cbb654d1c324dda5dbe9fce6ed4fbad163>;
+      dct:source <config://forms/bicycle-infrastructure/bevestiging-voorschot/versions/20220110162327-initial-version/form.ttl>.
+
+    # Submission period for the "Bevestiging voorschot" step
+    <http://data.lblod.info/id/periodes/130eebea-a1ac-411a-80fc-bb88857c0861>
+      a m8g:PeriodOfTime;
+      mu:uuid """130eebea-a1ac-411a-80fc-bb88857c0861""";
+      m8g:startTime "2026-05-01T00:00:00Z"^^xsd:dateTime;
+      m8g:endTime "2030-12-31T22:59:59Z"^^xsd:dateTime. 
+  }
+}

--- a/config/migrations/2026/20260113114731-fietsinstrastructuur/20260416130724-add-new-step-4-bevestiging-voorschot.sparql
+++ b/config/migrations/2026/20260113114731-fietsinstrastructuur/20260416130724-add-new-step-4-bevestiging-voorschot.sparql
@@ -31,7 +31,7 @@ INSERT DATA {
       qb:order 3;
       xkos:previous <http://lblod.data.info/id/subsidie-application-flow-steps/ad08beb8-b4a5-4a0e-ae99-1174b3b47d47>;
       dct:references <http://data.lblod.info/id/subsidy-procedural-steps/1e712857-b865-4b91-b125-846c4650544a>;
-      dct:isPartOf <http://lblod.data.info/id/subsidie-application-flows/26e0050a-3c55-4e54-8212-82b77280b17a>, <http://lblod.data.info/id/subsidie-application-flows/1a7fb92ca5e7a948c687bda5754233cbb654d1c324dda5dbe9fce6ed4fbad163>;
+      dct:isPartOf <http://lblod.data.info/id/subsidie-application-flows/26e0050a-3c55-4e54-8212-82b77280b17a>, <http://lblod.data.info/id/subsidie-application-flows/1a7fb92ca5e7a948c687bda5754233cbb654d1c324dda5dbe9fce6ed4fbad163>, <http://lblod.data.info/id/subsidie-application-flows/6d850270-a84b-466d-a572-84a17a734267>;
       dct:source <config://forms/bicycle-infrastructure/bevestiging-voorschot/versions/20220110162327-initial-version/form.ttl>.
 
     # Submission period for the "Bevestiging voorschot" step

--- a/config/migrations/2026/20260113114731-fietsinstrastructuur/20260416130724-add-new-step-4-bevestiging-voorschot.sparql
+++ b/config/migrations/2026/20260113114731-fietsinstrastructuur/20260416130724-add-new-step-4-bevestiging-voorschot.sparql
@@ -20,7 +20,7 @@ INSERT DATA {
     # Create new subsidy-procedural-step
     <http://data.lblod.info/id/subsidy-procedural-steps/1e712857-b865-4b91-b125-846c4650544a> a subsidie:Subsidieprocedurestap;
       mu:uuid "1e712857-b865-4b91-b125-846c4650544a";
-      dct:description """Bevestiging voorschot""";
+      dct:description """Bevestiging voorschot/saldo""";
       subsidie:Subsidieprocedurestap.type <http://lblod.data.gift/concepts/ee855aae-eb10-44aa-ae01-38c4f6cca0f6>;
       mobiliteit:periode <http://data.lblod.info/id/periodes/130eebea-a1ac-411a-80fc-bb88857c0861>.
 

--- a/config/migrations/2026/20260113114731-fietsinstrastructuur/20260416130724-add-new-step-4-bevestiging-voorschot.sparql
+++ b/config/migrations/2026/20260113114731-fietsinstrastructuur/20260416130724-add-new-step-4-bevestiging-voorschot.sparql
@@ -8,6 +8,7 @@ PREFIX cpsv: <http://purl.org/vocab/cpsv#>
 PREFIX xkos: <http://rdf-vocabulary.ddialliance.org/xkos#>
 PREFIX adms: <http://www.w3.org/ns/adms#>
 PREFIX common: <http://www.w3.org/2007/uwa/context/common.owl#>
+PREFIX m8g: <http://data.europa.eu/m8g/>
 
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {

--- a/config/migrations/2026/20260113114731-fietsinstrastructuur/20260417103813-set-fietsinfrastructuur-step-4-active.sparql
+++ b/config/migrations/2026/20260113114731-fietsinstrastructuur/20260417103813-set-fietsinfrastructuur-step-4-active.sparql
@@ -1,0 +1,36 @@
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX common: <http://www.w3.org/2007/uwa/context/common.owl#>
+PREFIX m8g: <http://data.europa.eu/m8g/>
+PREFIX qb: <http://purl.org/linked-data/cube#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX terms: <http://purl.org/dc/terms/>
+
+# This query sets the new step 4 (bevestiging voorschot) as active for anyone that has submitted the aanvraag uitbetaling step
+
+DELETE {
+    GRAPH ?g {
+        ?consumption adms:status ?status;
+                     common:active ?activeStep.
+    }
+}
+INSERT {
+    GRAPH ?g {
+        ?consumption <http://www.w3.org/2007/uwa/context/common.owl#active> <http://data.lblod.info/id/subsidy-procedural-steps/1e712857-b865-4b91-b125-846c4650544a> ;
+                     adms:status <http://lblod.data.gift/concepts/c849ca98-455d-4f31-9e95-a3d9d06e4497> ;
+                     common:active <http://data.lblod.info/id/subsidie-application-flow-steps/e78d8615-6595-4f29-bea6-49e26e6696bd> .
+    }
+}
+WHERE {
+    GRAPH ?g {
+        ?consumption <http://data.vlaanderen.be/ns/transactie#isInstantieVan> <http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2> ;
+                     adms:status ?status ;
+                     terms:source ?applicationForm .
+        OPTIONAL { ?consumption common:active ?activeStep . }
+        ?applicationForm adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> ;
+                         terms:isPartOf ?flowStep .
+    }
+    GRAPH ?public {
+        ?flowStep qb:order 1 .
+    }
+}

--- a/config/migrations/2026/20260113114731-fietsinstrastructuur/20260417103813-set-fietsinfrastructuur-step-4-active.sparql
+++ b/config/migrations/2026/20260113114731-fietsinstrastructuur/20260417103813-set-fietsinfrastructuur-step-4-active.sparql
@@ -16,8 +16,7 @@ DELETE {
 }
 INSERT {
     GRAPH ?g {
-        ?consumption <http://www.w3.org/2007/uwa/context/common.owl#active> <http://data.lblod.info/id/subsidy-procedural-steps/1e712857-b865-4b91-b125-846c4650544a> ;
-                     adms:status <http://lblod.data.gift/concepts/c849ca98-455d-4f31-9e95-a3d9d06e4497> ;
+        ?consumption adms:status <http://lblod.data.gift/concepts/c849ca98-455d-4f31-9e95-a3d9d06e4497> ;
                      common:active <http://data.lblod.info/id/subsidie-application-flow-steps/e78d8615-6595-4f29-bea6-49e26e6696bd> .
     }
 }
@@ -26,7 +25,9 @@ WHERE {
         ?consumption <http://data.vlaanderen.be/ns/transactie#isInstantieVan> <http://lblod.data.gift/concepts/70cc4947-33a3-4d26-82e0-2e1eacd2fea2> ;
                      adms:status ?status ;
                      terms:source ?applicationForm .
+
         OPTIONAL { ?consumption common:active ?activeStep . }
+
         ?applicationForm adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> ;
                          terms:isPartOf ?flowStep .
     }

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/tailored/source/extractors/bank-info-extractor.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/tailored/source/extractors/bank-info-extractor.js
@@ -1,0 +1,63 @@
+const FORM_DATA_URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'bike-subsidy/request-balance/bank-info-extractor',
+  execute: async (store, graphs, lib, target, source = null) => {
+
+    if (!source)
+      source = target;
+
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SCHEMA =
+        new $rdf.Namespace('http://schema.org/');
+    const DCT =
+        new $rdf.Namespace('http://purl.org/dc/terms/');
+    const RDF =
+        new $rdf.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+
+    const bankAccount = new $rdf.NamedNode(FORM_DATA_URI_BASE + mu.uuid());
+
+    store.add(
+        $rdf.sym(target.uri),
+        SCHEMA('bankAccount'),
+        $rdf.sym(bankAccount),
+        graphs.additions);
+
+    store.add(
+        $rdf.sym(bankAccount),
+        RDF_TYPE,
+        SCHEMA('BankAccount'),
+        graphs.additions);
+
+    const {iban} = await getGenericInfo(source.uri, mu, sudo);
+
+    if (iban)
+      store.add(
+          $rdf.sym(bankAccount),
+          SCHEMA('identifier'),
+          iban.value,
+          graphs.additions);
+  },
+};
+
+async function getGenericInfo(uri, mu, sudo) {
+  const {results} = await sudo.querySudo(`PREFIX schema: <http://schema.org/>
+
+SELECT DISTINCT ?iban
+WHERE {
+  GRAPH ?g {
+    ${mu.sparqlEscapeUri(uri)}
+      schema:bankAccount ?bankAccount.   
+    OPTIONAL { 
+       ?bankAccount schema:identifier ?iban.
+    }
+  }
+}`);
+
+  if (results.bindings.length) {
+    return results.bindings[0];
+  }
+  return null;
+}

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/tailored/source/extractors/contact-info-extractor.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/tailored/source/extractors/contact-info-extractor.js
@@ -1,0 +1,92 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'bike-subsidy/request-balance/contact-info-extractor',
+  execute: async (store, graphs, lib, target, source) => {
+
+    if (!source)
+      source = target;
+
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SCHEMA = new $rdf.Namespace('http://schema.org/');
+    const FOAF = new $rdf.Namespace('http://xmlns.com/foaf/0.1/');
+
+    const contactPoint = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+    store.add(
+        $rdf.sym(target.uri),
+        SCHEMA('contactPoint'),
+        $rdf.sym(contactPoint),
+        graphs.additions);
+
+    store.add(
+        $rdf.sym(contactPoint),
+        RDF_TYPE,
+        SCHEMA('ContactPoint'),
+        graphs.additions);
+  
+
+    const {firstName, familyName, email, telephone} =
+        await getGenericInfo(source.uri, mu, sudo);
+
+    if (familyName)
+      store.add(
+          $rdf.sym(contactPoint),
+          FOAF('familyName'),
+          familyName.value,
+          graphs.additions);
+    if (firstName)
+      store.add(
+          $rdf.sym(contactPoint),
+          FOAF('firstName'),
+          firstName.value,
+          graphs.additions);
+    if (email)
+      store.add(
+          $rdf.sym(contactPoint),
+          SCHEMA('email'),
+          email.value,
+          graphs.additions);
+    if (telephone)
+      store.add(
+          $rdf.sym(contactPoint),
+          SCHEMA('telephone'),
+          telephone.value,
+          graphs.additions);
+  },
+};
+
+async function getGenericInfo(uri, mu, sudo) {
+  const {results} = await sudo.querySudo(`PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+PREFIX schema: <http://schema.org/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+SELECT DISTINCT ?firstName ?familyName ?email ?telephone
+WHERE {
+  GRAPH ?g {
+    ${mu.sparqlEscapeUri(uri)}
+      schema:contactPoint ?contactPoint.
+
+    OPTIONAL { 
+        ?contactPoint foaf:familyName ?familyName.
+    }
+    OPTIONAL { 
+        ?contactPoint foaf:firstName ?firstName.
+    }
+    OPTIONAL { 
+        ?contactPoint schema:email ?email.
+    }  
+    OPTIONAL { 
+        ?contactPoint schema:telephone ?telephone.
+    }
+  }          
+}`);
+
+  if (results.bindings.length) {
+    return results.bindings[0];
+  }
+  return null;
+}

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/tailored/source/extractors/generic-info-extractor.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/tailored/source/extractors/generic-info-extractor.js
@@ -1,0 +1,54 @@
+module.exports = {
+  name: 'bike-subsidy/request-balance/generic-info-extractor',
+  execute: async (store, graphs, lib, target, source) => {
+
+    if (!source)
+      source = target;
+
+    const {$rdf, mu, sudo} = lib;
+
+    const LBLOD_SUBSIDIE = new $rdf.Namespace(
+        'http://lblod.data.gift/vocabularies/subsidie/');
+    const NIE = new $rdf.Namespace(
+        'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#');
+
+    const {projectName, identifier} =
+        await getGenericInfo(source.uri, mu, sudo);
+
+    if (projectName)
+      store.add(
+          $rdf.sym(target.uri),
+          LBLOD_SUBSIDIE('projectName'),
+          projectName.value,
+          graphs.additions);
+
+    if (identifier)
+      store.add(
+          $rdf.sym(target.uri),
+          NIE('identifier'),
+          identifier.value,
+          graphs.additions);
+  },
+};
+
+async function getGenericInfo(uri, mu, sudo) {
+  const {results} = await sudo.querySudo(`PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+SELECT DISTINCT ?projectName ?identifier
+WHERE {
+  GRAPH ?g {
+    OPTIONAL { 
+        ${mu.sparqlEscapeUri(uri)} lblodSubsidie:projectName ?projectName.
+    }
+    OPTIONAL { 
+        ${mu.sparqlEscapeUri(uri)} nie:identifier ?identifier.
+    }
+  }
+}`);
+
+  if (results.bindings.length) {
+    return results.bindings[0];
+  }
+  return null;
+}

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/tailored/source/extractors/missing-types-extractor.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/tailored/source/extractors/missing-types-extractor.js
@@ -1,0 +1,28 @@
+const URI_BASE = 'http://data.lblod.info/form-data/nodes/';
+
+module.exports = {
+  name: 'climate/bicycle-infrastructure/proposal/missing-types-extractor',
+  execute: async (store, graphs, lib, source) => {
+    const {$rdf, mu, sudo} = lib;
+
+    const RDF_TYPE = new $rdf.NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    const SUBSIDIE = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/');
+    const PICTURE_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/pictures-upload/');
+    const INVOICE_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/invoice-upload/');
+    const REPORT_UPLOAD = new $rdf.Namespace('http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure/report-upload/');
+
+    const pictureUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const invoiceUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+    const reportUpload = new $rdf.NamedNode(URI_BASE + mu.uuid());
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('picturesUpload'), $rdf.sym(pictureUpload), graphs.additions);
+    store.add($rdf.sym(pictureUpload), RDF_TYPE, PICTURE_UPLOAD('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('invoiceUpload'), $rdf.sym(invoiceUpload), graphs.additions);
+    store.add($rdf.sym(invoiceUpload), RDF_TYPE, INVOICE_UPLOAD('FormData'), graphs.additions);
+
+    store.add($rdf.sym(source.uri), SUBSIDIE('reportUpload'), $rdf.sym(reportUpload), graphs.additions);
+    store.add($rdf.sym(reportUpload), RDF_TYPE, REPORT_UPLOAD('FormData'), graphs.additions);
+
+  }
+}

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/tailored/source/index.js
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/tailored/source/index.js
@@ -1,0 +1,55 @@
+const genericInfo = require(
+    './extractors/generic-info-extractor');
+const contactInfo = require(
+    './extractors/contact-info-extractor');
+const bankInfo = require(
+    './extractors/bank-info-extractor');
+const missingTypesExtractor = require('./extractors/missing-types-extractor');
+
+precedingFormExtractor = (extractors) =>
+    Object.assign(
+        {
+          name: 'bike-subsidy/request-balance/previous-form-as-source',
+          execute: async (store, graphs, lib, form) => {
+            const {mu, sudo} = lib;
+            const {results} = await sudo.querySudo(`PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX xkos: <http://rdf-vocabulary.ddialliance.org/xkos#>
+
+SELECT DISTINCT ?previousForm where {
+  GRAPH ?g {
+    ${mu.sparqlEscapeUri(form.uri)} dct:isPartOf ?currentStep .
+    ?smc dct:source ${mu.sparqlEscapeUri(form.uri)} .
+    ?previousForm dct:isPartOf ?previousStep .
+    ?smc dct:source ?previousForm .
+  }
+  GRAPH ?h {
+    ?currentStep xkos:previous ?previousStep .
+  }
+}`);
+            if (!results.bindings.length)
+              throw `Failed to find a preciding form for <${form.uri}>, are you sure this is part of a flow?`;
+            const source = results.bindings[0].previousForm.value;
+            for (let extractor of extractors) {
+              try {
+                await extractor.execute(
+                    store,
+                    graphs,
+                    lib,
+                    form,
+                    {uri: source});
+              } catch (e) {
+                console.warn(
+                    `Failed to execute inner extractor for ${extractor.name}`);
+                console.log(e);
+              }
+            }
+          },
+        },
+    );
+
+/**
+ * NOTE: order of execution bound to position in the array
+ */
+module.exports = [
+  precedingFormExtractor([genericInfo, contactInfo, bankInfo]), missingTypesExtractor,
+];

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/versions/20220110162327-initial-version/form.json
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/versions/20220110162327-initial-version/form.json
@@ -1,0 +1,103 @@
+{
+  "source": {
+    "prefixes": [
+      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
+      "PREFIX dct: <http://purl.org/dc/terms/>",
+      "PREFIX lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>",
+      "PREFIX schema: <http://schema.org/>",
+      "PREFIX foaf: <http://xmlns.com/foaf/0.1/>",
+      "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>",
+      "PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>",
+      "PREFIX bicycleInfrastructure: <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#>"
+    ],
+    "properties": [
+      "lblodSubsidie:projectName",
+      "lblodSubsidie:totalEstimateCost",    
+      "nie:identifier",
+      {
+        "s-prefix": "lblodSubsidie:picturesUpload",
+        "properties": [
+          {
+            "s-prefix": "dct:hasPart",
+            "properties": [
+              "rdf:type"
+            ]
+          }
+        ]
+      },
+      {
+        "s-prefix": "lblodSubsidie:invoiceUpload",
+        "properties": [
+          {
+            "s-prefix": "dct:hasPart",
+            "properties": [
+              "rdf:type"
+            ]
+          }
+        ]
+      },
+      {
+        "s-prefix": "lblodSubsidie:reportUpload",
+        "properties": [
+          {
+            "s-prefix": "dct:hasPart",
+            "properties": [
+              "rdf:type"
+            ]
+          }
+        ]
+      },
+      {
+        "s-prefix": "schema:contactPoint",
+        "properties": [
+          "foaf:firstName",
+          "foaf:familyName",
+          "schema:telephone",
+          "schema:email"
+        ]
+      },
+      {
+        "s-prefix": "schema:bankAccount",
+        "properties": [
+          "schema:identifier",
+          {
+            "s-prefix": "dct:hasPart",
+            "properties": [
+              "rdf:type"
+            ]
+          }
+        ]
+      },
+      {
+        "s-prefix": "bicycleInfrastructure:estimatedCostTable",
+        "properties": [
+          "bicycleInfrastructure:validEstimatedCostTable",
+          {
+            "s-prefix": "bicycleInfrastructure:estimatedCostEntry",
+            "properties": [
+              "bicycleInfrastructure:costEstimationType",
+              "bicycleInfrastructure:cost",
+              "bicycleInfrastructure:share",
+              "ext:index"
+            ]
+          }
+        ]
+      },
+      {
+        "s-prefix": "bicycleInfrastructure:objectiveTable",
+        "properties": [
+          "bicycleInfrastructure:validObjectiveTable",
+          {
+            "s-prefix": "bicycleInfrastructure:objectiveEntry",
+            "properties": [
+              "bicycleInfrastructure:approachType",
+              "bicycleInfrastructure:directionType",
+              "bicycleInfrastructure:bikeLaneType",
+              "bicycleInfrastructure:kilometers"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/versions/20220110162327-initial-version/form.ttl
+++ b/config/subsidy-application-management/forms/bicycle-infrastructure/bevestiging-voorschot/versions/20220110162327-initial-version/form.ttl
@@ -1,0 +1,392 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix fieldGroups: <http://data.lblod.info/field-groups/> .
+@prefix fields: <http://data.lblod.info/fields/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix schema: <http://schema.org/>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix lblodSubsidie: <http://lblod.data.gift/vocabularies/subsidie/>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/>.
+@prefix bicycleInfrastructure: <http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#>.
+
+# TODO redo order
+##########################################################
+# Property groups
+##########################################################
+# DONE
+fields:3b82e926-b7d7-4613-a005-1ba1bf03f4f3 a form:PropertyGroup;
+    mu:uuid "3b82e926-b7d7-4613-a005-1ba1bf03f4f3";
+    sh:description "parent property-group, used to group fields and property-groups together";
+    sh:order 1 .
+# DONE
+fields:56a33109-bf89-4897-9b93-fc5b1ea75ab6 a form:PropertyGroup;
+    mu:uuid "56a33109-bf89-4897-9b93-fc5b1ea75ab6";
+    sh:description "General information";
+    sh:order 2;
+    sh:name "Algemeen" ;
+    sh:group fields:3b82e926-b7d7-4613-a005-1ba1bf03f4f3 .
+# DONE
+fields:3817826e-e5c5-45a5-bbdc-97bfbb3f198e a form:PropertyGroup;
+    mu:uuid "3817826e-e5c5-45a5-bbdc-97bfbb3f198e";
+    sh:description "Contact information";
+    sh:order 3;
+    sh:name "Contactgegevens contactpersoon" ;
+    form:help "Dit is de persoon die gecontacteerd wordt bij de opvolging van dit dossier." ;
+    sh:group fields:3b82e926-b7d7-4613-a005-1ba1bf03f4f3 .
+# DONE
+fields:99ec3271-086a-4195-9ef7-e7773f4eac37 a form:PropertyGroup;
+    mu:uuid "99ec3271-086a-4195-9ef7-e7773f4eac37";
+    sh:description "Upload";
+    sh:order 4;
+    sh:group fields:3b82e926-b7d7-4613-a005-1ba1bf03f4f3 .
+# DONE
+fields:411902aa-dfbf-4c0e-b6e9-a3882d730a3c a form:PropertyGroup;
+    mu:uuid "411902aa-dfbf-4c0e-b6e9-a3882d730a3c";
+    sh:description "Payment information";
+    sh:order 5;
+    sh:name "Betaling" ;
+    sh:group fields:3b82e926-b7d7-4613-a005-1ba1bf03f4f3 .
+
+##########################################################
+# Bicycle infrastructure: case-number
+##########################################################
+# DONE
+fields:6aa476d8-e0ec-4321-8120-660ea6846062 a form:Field ;
+mu:uuid "6aa476d8-e0ec-4321-8120-660ea6846062";
+sh:name "Dossiernummer" ;
+sh:order 10 ;
+sh:path nie:identifier ;
+form:validations
+  [ a form:RequiredConstraint ;
+  form:grouping form:Bag ;
+  sh:resultMessage "Dit veld is verplicht."@nl;
+  sh:path nie:identifier
+  ] ;
+form:options  """{"prefix" : "fiets-subsidie-"}""" ;
+form:help "Dit nummer werd uniek gegenereerd voor uw subsidie aanvraag. Gelieve dit bij iedere communicatie te vermelden." ;
+form:displayType displayTypes:caseNumber ;
+sh:group fields:56a33109-bf89-4897-9b93-fc5b1ea75ab6  .
+
+##########################################################
+# Bicycle infrastructure: project name
+##########################################################
+# DONE
+fields:ee2998c7-b964-4147-a683-32c2f232a637 a form:Field ;
+    mu:uuid "ee2998c7-b964-4147-a683-32c2f232a637";
+    sh:name "Projectnaam" ;
+    sh:order 11 ;
+    sh:path lblodSubsidie:projectName ;
+    form:validations
+      [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht."@nl;
+      sh:path lblodSubsidie:projectName
+      ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:56a33109-bf89-4897-9b93-fc5b1ea75ab6 .
+
+
+##########################################################
+# Contact person info
+##########################################################
+# DONE
+fields:6f8210f9-313b-49cb-be0c-df46126b1419 a form:Field ;
+    mu:uuid "6f8210f9-313b-49cb-be0c-df46126b1419";
+    sh:name "Voornaam contactpersoon" ;
+    sh:order 20 ;
+    sh:path ( schema:contactPoint foaf:firstName ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint foaf:firstName ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:3817826e-e5c5-45a5-bbdc-97bfbb3f198e .
+# DONE
+fields:d45e6363-7458-4e8a-a5a9-cbd66f8d4f78 a form:Field ;
+    mu:uuid "d45e6363-7458-4e8a-a5a9-cbd66f8d4f78";
+    sh:name "Familienaam contactpersoon" ;
+    sh:order 21 ;
+    sh:path ( schema:contactPoint foaf:familyName ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint foaf:familyName ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:3817826e-e5c5-45a5-bbdc-97bfbb3f198e .
+# DONE
+fields:c632a79e-6f3e-41c7-8230-ca90ffe601f2 a form:Field ;
+    mu:uuid "c632a79e-6f3e-41c7-8230-ca90ffe601f2";
+    sh:name "Telefoonnummer" ;
+    sh:order 22 ;
+    sh:path ( schema:contactPoint schema:telephone ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint schema:telephone ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidPhoneNumber ;
+        form:grouping form:MatchEvery ;
+        form:defaultCountry "BE" ;
+        sh:path ( schema:contactPoint schema:telephone ) ;
+        sh:resultMessage "Geef een geldig telefoonnummer in."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:3817826e-e5c5-45a5-bbdc-97bfbb3f198e .
+# DONE
+fields:2dd1f378-fa30-46a4-b7a6-969838bc89fd a form:Field ;
+    mu:uuid "2dd1f378-fa30-46a4-b7a6-969838bc89fd";
+    sh:name "Mailadres" ;
+    sh:order 23 ;
+    sh:path ( schema:contactPoint schema:email ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:contactPoint schema:email ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidEmail ;
+        form:grouping form:MatchEvery ;
+        sh:path ( schema:contactPoint schema:email ) ;
+        sh:resultMessage "Geef een geldig e-mailadres op."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:3817826e-e5c5-45a5-bbdc-97bfbb3f198e .
+
+##########################################################
+# Bicycle infrastructure: pictures-upload
+##########################################################
+# DONE
+fields:965d24ef-99ae-4f07-9a5d-7a9e083a7ca1 a form:Field ;
+    mu:uuid "965d24ef-99ae-4f07-9a5d-7a9e083a7ca1";
+    sh:name "Upload foto's" ;
+    form:help "Laad hier een of meerdere foto’s op van de situatie na de afronding van het project.";
+    sh:order 14 ;
+    sh:path ( lblodSubsidie:picturesUpload dct:hasPart ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht."@nl;
+      sh:path ( lblodSubsidie:picturesUpload dct:hasPart ) ;
+    ] ;
+    form:displayType displayTypes:files ;
+    sh:group fields:99ec3271-086a-4195-9ef7-e7773f4eac37 .
+# DONE
+fields:4f9bbe22-c562-4ff0-87ac-cc47cc01e224 a form:Field ;
+    mu:uuid "4f9bbe22-c562-4ff0-87ac-cc47cc01e224" ;
+    sh:name "Type RemoteDataObject or FileDataObject [hidden input]" ;
+    sh:order 16 ;
+    sh:path ( lblodSubsidie:picturesUpload dct:hasPart rdf:type );
+    sh:group fields:99ec3271-086a-4195-9ef7-e7773f4eac37 .
+
+##########################################################
+# Bicycle infrastructure: invoice-upload
+##########################################################
+# DONE
+fields:36210e53-38f0-4135-b338-23ec58153c7d a form:Field ;
+    mu:uuid "36210e53-38f0-4135-b338-23ec58153c7d";
+    sh:name "Upload Facturen" ;
+    form:help "Laad hier alle facturen op voor het afgeronde project.";
+    sh:order 24 ;
+    sh:path ( lblodSubsidie:invoiceUpload dct:hasPart ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht."@nl;
+      sh:path ( lblodSubsidie:invoiceUpload dct:hasPart ) ;
+    ] ;
+    form:displayType displayTypes:files ;
+    sh:group fields:99ec3271-086a-4195-9ef7-e7773f4eac37 .
+# DONE
+fields:f30c5cef-0fd2-42d9-86de-82e7ea0d4d7c a form:Field ;
+    mu:uuid "f30c5cef-0fd2-42d9-86de-82e7ea0d4d7c" ;
+    sh:name "Type RemoteDataObject or FileDataObject [hidden input]" ;
+    sh:order 26 ;
+    sh:path ( lblodSubsidie:invoiceUpload dct:hasPart rdf:type );
+    sh:group fields:99ec3271-086a-4195-9ef7-e7773f4eac37 .
+
+##########################################################
+# Bicycle infrastructure: report-upload
+##########################################################
+# DONE
+fields:ca288d9e-7917-4c7a-8b1d-510b32892548 a form:Field ;
+    mu:uuid "ca288d9e-7917-4c7a-8b1d-510b32892548";
+    sh:name "Upload verslag oplevering van de werken" ;
+    form:help "Laad hier het verslag op van de oplevering van de werken.";
+    sh:order 25 ;
+    sh:path ( lblodSubsidie:reportUpload dct:hasPart ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht."@nl;
+      sh:path ( lblodSubsidie:reportUpload dct:hasPart ) ;
+    ] ;
+    form:displayType displayTypes:files ;
+    sh:group fields:99ec3271-086a-4195-9ef7-e7773f4eac37 .
+# DONE
+fields:94f3ab67-edb9-44fb-a79a-75685d2e3a5d a form:Field ;
+    mu:uuid "94f3ab67-edb9-44fb-a79a-75685d2e3a5d" ;
+    sh:name "Type RemoteDataObject or FileDataObject [hidden input]" ;
+    sh:order 27 ;
+    sh:path ( lblodSubsidie:reportUpload dct:hasPart rdf:type );
+    sh:group fields:99ec3271-086a-4195-9ef7-e7773f4eac37 .
+
+##########################################################
+# Payment info
+##########################################################
+# DONE
+fields:aa920ed0-0403-4a6f-9490-fc5ccdd324d7 a form:Field ;
+    mu:uuid "aa920ed0-0403-4a6f-9490-fc5ccdd324d7";
+    sh:name "Rekeningnummer uitbetaling" ;
+    form:help "IBAN: BE00 0000 0000 0000" ;
+    sh:order 30 ;
+    sh:path ( schema:bankAccount schema:identifier ) ;
+    form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path ( schema:bankAccount schema:identifier ) ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ,
+    [ a form:ValidIBAN ;
+        form:grouping form:MatchEvery ;
+        sh:path ( schema:bankAccount schema:identifier ) ;
+        sh:resultMessage "Geef een geldig IBAN op."@nl
+    ] ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:411902aa-dfbf-4c0e-b6e9-a3882d730a3c .
+# DONE
+fields:bc5ab946-74c2-43e2-b990-961891781abc a form:Field ;
+    mu:uuid "bc5ab946-74c2-43e2-b990-961891781abc";
+    sh:name "Voeg een bevestingsbrief toe dat dit rekeningnummer gebruikt mag worden, ondertekend door de burgemeester en medeondertekend door de financieel directeur." ;
+    form:help "Deze brief moet enkel toegevoegd worden als dit niet het rekeningnummer is waarop het aandeel van het gemeentefonds wordt gestort." ;
+    sh:order 31 ;
+    sh:path ( schema:bankAccount dct:hasPart ) ;
+    form:displayType displayTypes:files ;
+    sh:group fields:411902aa-dfbf-4c0e-b6e9-a3882d730a3c .
+
+##########################################################
+# Bicycle infrastructure: Estimated Cost Table
+##########################################################
+# DONE
+fields:2182bc4f-1dd9-46db-a04d-4aa49fbab423 a form:Field ;
+    mu:uuid "2182bc4f-1dd9-46db-a04d-4aa49fbab423";
+    sh:name "Totale kostprijs" ;
+    sh:order 32 ;
+    sh:path bicycleInfrastructure:estimatedCostTable ;
+    form:displayType displayTypes:estimatedCostTable ;
+    form:options """{"isAanvraagStep" : true}""" ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Gelieve de tabel correct in te vullen." ;
+      sh:path ( bicycleInfrastructure:estimatedCostTable bicycleInfrastructure:validEstimatedCostTable ) ] ;
+    sh:group fields:411902aa-dfbf-4c0e-b6e9-a3882d730a3c .
+
+# DONE
+fields:45f373b3-92c8-42df-8806-4dafe1a43c2a a form:Field ;
+    mu:uuid "45f373b3-92c8-42df-8806-4dafe1a43c2a" ;
+    sh:name "Valid Estimated Cost Table [hidden input]" ;
+    sh:order 14 ;
+    sh:path ( bicycleInfrastructure:estimatedCostTable bicycleInfrastructure:validEstimatedCostTable );
+    sh:group fields:411902aa-dfbf-4c0e-b6e9-a3882d730a3c .
+
+##########################################################
+# Bicycle infrastructure: Objective Table
+##########################################################
+
+fields:15be219f-966a-43dc-b9e3-950ac5065aac a form:Field ;
+    mu:uuid "15be219f-966a-43dc-b9e3-950ac5065aac";
+    sh:name "Realisatie" ;
+    form:help "Als u bvb. bij een traject van 1km langs beide kanten van de weg een fietspad aanlegt of vernieuwt, vul dan 2km in";
+    sh:order 33 ;
+    sh:path bicycleInfrastructure:objectiveTable ;
+    form:displayType displayTypes:objectiveTable ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Gelieve de tabel correct in te vullen." ;
+      sh:path ( bicycleInfrastructure:objectiveTable bicycleInfrastructure:validObjectiveTable ) ] ;
+    sh:group fields:411902aa-dfbf-4c0e-b6e9-a3882d730a3c  .
+
+
+fields:7432d520-a20c-48b7-8057-01af2ba430a9 a form:Field ;
+    mu:uuid "7432d520-a20c-48b7-8057-01af2ba430a9" ;
+    sh:name "Valid Objective Table [hidden input]" ;
+    sh:order 18 ;
+    sh:path ( bicycleInfrastructure:objectiveTable bicycleInfrastructure:validObjectiveTable );
+    sh:group fields:411902aa-dfbf-4c0e-b6e9-a3882d730a3c .
+
+##########################################################
+# Linking fields to form
+##########################################################
+
+fieldGroups:main a form:FieldGroup ;
+    mu:uuid "1f3cf92c-aa5f-4708-85c6-77aabbc8989f" ;
+    form:hasField
+
+        ### Case number
+        fields:6aa476d8-e0ec-4321-8120-660ea6846062 ,
+
+        ### Project name
+        fields:ee2998c7-b964-4147-a683-32c2f232a637 ,
+
+        ### Contact person info
+        fields:6f8210f9-313b-49cb-be0c-df46126b1419 ,
+
+        ### Familyname
+        fields:d45e6363-7458-4e8a-a5a9-cbd66f8d4f78 ,
+
+        ### Telephone number
+        fields:c632a79e-6f3e-41c7-8230-ca90ffe601f2 ,
+
+        ### Mail address
+        fields:2dd1f378-fa30-46a4-b7a6-969838bc89fd ,
+
+        ### Pictures upload
+        fields:965d24ef-99ae-4f07-9a5d-7a9e083a7ca1,
+
+        ### Pictures upload [HIDDEN]
+        fields:4f9bbe22-c562-4ff0-87ac-cc47cc01e224,
+
+        ### Invoices upload
+        fields:36210e53-38f0-4135-b338-23ec58153c7d ,
+
+        ### Invoices upload [HIDDEN]
+        fields:f30c5cef-0fd2-42d9-86de-82e7ea0d4d7c ,
+
+        ### Report upload
+        fields:ca288d9e-7917-4c7a-8b1d-510b32892548 ,
+
+        ### Report upload [HIDDEN]
+        fields:94f3ab67-edb9-44fb-a79a-75685d2e3a5d ,
+
+        ### Bank account
+        fields:aa920ed0-0403-4a6f-9490-fc5ccdd324d7 ,
+
+        ### Confirmation letter
+        fields:bc5ab946-74c2-43e2-b990-961891781abc ,
+
+        ### Estimated cost Table
+        fields:2182bc4f-1dd9-46db-a04d-4aa49fbab423 ,
+
+        ### Estimated cost Table [HIDDEN]
+        fields:45f373b3-92c8-42df-8806-4dafe1a43c2a ,
+
+        ### Objective Table
+        fields:15be219f-966a-43dc-b9e3-950ac5065aac ,
+
+        ### Objective Table [HIDDEN]
+        fields:7432d520-a20c-48b7-8057-01af2ba430a9 .
+
+form:6b70a6f0-cce2-4afe-81f5-5911f45b0b27 a form:Form ;
+    mu:uuid "6b70a6f0-cce2-4afe-81f5-5911f45b0b27" ;
+    form:hasFieldGroup fieldGroups:main .


### PR DESCRIPTION
## Description
This ads a new step 4 to the fietsinfrastructuur subsidy. IMPORTANT, it also sets the 4th step to ACTIVE. It is important that this only gets deployed AFTER 30 april 23h59

## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
Setup with remote data. Make sure migrations ran correctly

## How to test
There are a couple of cases. Here is an overview:
- Everyone that has a fietssubdiy should SEE step 4
- Starting from 1 mei (update the date in the migration to simulate this) everyone that COMPLETED step 2 (aanvraag uitbetaling) should be able to fill in step 4 
- People that did not submit step 2 should not be able to submit step 4
(note: step 3 in this case is not relevant for deciding if they should or should not be able to submit step 4)

<img width="343" height="628" alt="image" src="https://github.com/user-attachments/assets/74a9b3d6-21a8-458b-881e-d9af96313fad" />
