### PR TITLE
Nooddorpen Oekraine Subsidie - Update Deadline

### DIFF
--- a/config/migrations/2026/20260422101508-nooddorpen-oekraine/20260422101508-update-deadline-nooddorpen.sparql
+++ b/config/migrations/2026/20260422101508-nooddorpen-oekraine/20260422101508-update-deadline-nooddorpen.sparql
@@ -1,0 +1,27 @@
+PREFIX m8g: <http://data.europa.eu/m8g/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX dcterm: <http://purl.org/dc/terms/>
+
+# Oekraine nooddorpen
+# Update subsidy and step deadlines
+DELETE {
+  GRAPH ?g {
+    ?s m8g:endTime ?endTime .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    <http://data.lblod.info/id/periodes/5ecb1512-e8b3-40bf-a0c4-a4087090c093> m8g:endTime "2027-07-30T21:59:00Z"^^xsd:dateTime . 
+    <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> m8g:endTime "2027-07-30T21:59:00Z"^^xsd:dateTime . 
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?s {
+      <http://data.lblod.info/id/periodes/5ecb1512-e8b3-40bf-a0c4-a4087090c093>
+      <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c>
+    }
+    ?s m8g:endTime ?endTime .
+  }
+}

--- a/config/migrations/2026/20260422101508-nooddorpen-oekraine/20260422101508-update-deadline-nooddorpen.sparql
+++ b/config/migrations/2026/20260422101508-nooddorpen-oekraine/20260422101508-update-deadline-nooddorpen.sparql
@@ -12,8 +12,8 @@ DELETE {
 }
 INSERT {
   GRAPH ?g {
-    <http://data.lblod.info/id/periodes/5ecb1512-e8b3-40bf-a0c4-a4087090c093> m8g:endTime "2027-07-30T21:59:00Z"^^xsd:dateTime . 
-    <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> m8g:endTime "2027-07-30T21:59:00Z"^^xsd:dateTime . 
+    <http://data.lblod.info/id/periodes/5ecb1512-e8b3-40bf-a0c4-a4087090c093> m8g:endTime "2027-09-30T21:59:00Z"^^xsd:dateTime . 
+    <http://data.lblod.info/id/periodes/8265739f-2f05-4ada-8a30-c813b4bd783c> m8g:endTime "2027-09-30T21:59:00Z"^^xsd:dateTime . 
   }
 }
 WHERE {


### PR DESCRIPTION
## Description
This migration updates the deadline of the last step + subsidy to 30 september 2027

## Type of change

 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [x] Maintanance

## How to setup
Setup with server data. Make sure migrations ran

## How to test
Find existing forms and validate if the deadline has changed both of the subsidy and last step
