### PR TITLE
[DGS-638] E-inclusie: Update deadline to 31/08/2026

### DIFF
--- a/config/migrations/2026/20260604104923-e-inclusie/20260604104923-update-deadline.sparql
+++ b/config/migrations/2026/20260604104923-e-inclusie/20260604104923-update-deadline.sparql
@@ -1,0 +1,24 @@
+# Update e-inclusion deadline from 2026-06-30T21:59:00Z to 2026-08-31T21:59:59Z
+
+PREFIX m8g: <http://data.europa.eu/m8g/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+  GRAPH ?g {
+    ?period m8g:endTime "2026-06-30T21:59:00Z"^^xsd:dateTime .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?period m8g:endTime "2026-08-31T21:59:00Z"^^xsd:dateTime .
+  }
+}
+WHERE {
+  VALUES ?period {
+    <http://data.lblod.info/id/periodes/f727d567-e43e-4c1c-bd6a-6071ab83f903>
+  }
+
+  GRAPH ?g {
+    ?period m8g:endTime "2026-06-30T21:59:00Z"^^xsd:dateTime .
+  }
+}


### PR DESCRIPTION
## Description
This updates the deadline to 31 August 2026. ONLY FOR THOSE THAT HAD DEADLINE 30 JUNE 2026. This is a special case because e-inclusie stores deadlines in org graphs NOT IN PUBLIC 

## Type of change

 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [x] Maintanance

## How to setup
Preferably with server data, run migrations and mock login

## How to test
Check for deadline of existing consumptions
