### PR TITLE
[DGS-655] Ketenoverlast subsidy: Add access for VGC

### DIFF
--- a/config/migrations/2026/20260701145844-versterking-ketenaanpak-overlast/20260619142940-new-subsidy-versterking-ketenaanpak-overlast.sparql
+++ b/config/migrations/2026/20260701145844-versterking-ketenaanpak-overlast/20260619142940-new-subsidy-versterking-ketenaanpak-overlast.sparql
@@ -69,6 +69,7 @@ INSERT DATA {
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     <http://data.lblod.info/id/subsidy-measure-offers/254c7097-4c93-4d7e-a135-32ef18b0de00> <http://data.europa.eu/m8g/hasCriterion>
+      <http://data.lblod.info/id/criterions/80301a63-927c-48e5-8678-048c87c25847>, # VGC criterion
       <http://data.lblod.info/id/criterions/f5ea0615-0b0a-47db-a38c-6097ff80815d>. # Gemeente
   }
 }

--- a/config/migrations/2026/20260701145844-versterking-ketenaanpak-overlast/20260728143120-add-vgc-access-ketenaanpak.sparql
+++ b/config/migrations/2026/20260701145844-versterking-ketenaanpak-overlast/20260728143120-add-vgc-access-ketenaanpak.sparql
@@ -1,0 +1,6 @@
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/subsidy-measure-offers/254c7097-4c93-4d7e-a135-32ef18b0de00> <http://data.europa.eu/m8g/hasCriterion>
+      <http://data.lblod.info/id/criterions/80301a63-927c-48e5-8678-048c87c25847>. # VGC criterion
+  }
+}


### PR DESCRIPTION
## Description
VGC is a special case, it should also have access to ketenoverlast. We do this by adding its criterion to the subsidy

## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
Setup with server data, make sure migrations ran correctly

## How to test
Mock login with "Vlaamse Gemeenschapscommissie"
Create a new subsidy
Normally only ketenoverlast should be an option in the list (no need for testmode)